### PR TITLE
Add new frappe logo to frappe website header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.egg-info
 *.swp
 tags
+.kdev4/
+*.kdev4

--- a/frappe_theme/public/css/frappe_theme.css
+++ b/frappe_theme/public/css/frappe_theme.css
@@ -274,7 +274,6 @@ footer ul li {
 footer li a {
   text-decoration: none;
   color: #36414c;
-  font-size: 16px;
 }
 .social {
   text-align: center;

--- a/frappe_theme/public/img/frappe-bird-grey.svg
+++ b/frappe_theme/public/img/frappe-bird-grey.svg
@@ -1,13 +1,46 @@
-<?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="100%" height="100%" viewBox="0 0 260 260" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;">
-    <g>
-        <g>
-            <path d="M65.838,51.703L111.685,97.55" style="fill:rgb(255,120,61);fill-rule:nonzero;"/>
-            <path d="M142.07,214.331C140.972,214.331 139.892,213.904 139.083,213.099L63.699,138.15C62.899,137.355 62.45,136.273 62.45,135.145L62.45,51.703C62.45,49.364 64.346,47.468 66.683,47.468C69.023,47.468 70.919,49.364 70.919,51.703L70.919,133.385L137.833,199.913L137.833,149.073C137.833,146.735 139.729,144.839 142.067,144.839C144.407,144.839 146.303,146.735 146.303,149.073L146.303,210.095C146.303,211.806 145.274,213.349 143.694,214.006C143.17,214.225 142.617,214.331 142.07,214.331Z" style="fill:rgb(141,153,166);fill-rule:nonzero;"/>
-            <path d="M66.684,93.206L31.109,93.206C29.423,93.206 27.897,92.208 27.225,90.662C26.552,89.115 26.862,87.317 28.01,86.085L53.506,58.723L62.738,48.816C64.333,47.105 67.013,47.009 68.724,48.604C70.435,50.199 70.529,52.878 68.935,54.59L40.844,84.736L66.684,84.736C69.024,84.736 70.92,86.632 70.92,88.972C70.92,91.311 69.023,93.206 66.684,93.206Z" style="fill:rgb(141,153,166);fill-rule:nonzero;"/>
-            <path d="M111.685,101.784C110.588,101.784 109.492,101.362 108.663,100.516L63.663,54.669C62.024,52.999 62.05,50.317 63.719,48.68C65.389,47.041 68.07,47.067 69.708,48.736L114.708,94.584C116.347,96.253 116.321,98.934 114.652,100.572C113.826,101.381 112.756,101.784 111.685,101.784Z" style="fill:rgb(141,153,166);fill-rule:nonzero;"/>
-            <path d="M108.015,180.274C106.802,180.274 105.599,179.756 104.761,178.752C103.262,176.956 103.504,174.285 105.299,172.787L231.176,67.796L153.873,67.796L69.229,138.397C67.433,139.895 64.762,139.655 63.263,137.857C61.765,136.062 62.007,133.39 63.803,131.892L149.626,60.309C150.388,59.675 151.347,59.327 152.338,59.327L242.863,59.327C244.645,59.327 246.238,60.444 246.844,62.12C247.451,63.796 246.944,65.673 245.574,66.814L110.726,179.292C109.934,179.953 108.971,180.274 108.015,180.274Z" style="fill:rgb(141,153,166);fill-rule:nonzero;"/>
-        </g>
-    </g>
-</svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="100%"
+   height="100%"
+   viewBox="0 0 260 260"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;"
+   id="svg16"
+   sodipodi:docname="frappe-bird-grey.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"><metadata
+     id="metadata22"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs20" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1029"
+     id="namedview18"
+     showgrid="false"
+     inkscape:snap-global="false"
+     inkscape:zoom="2.5673415"
+     inkscape:cx="125.36812"
+     inkscape:cy="132.66533"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg16" /><path
+     inkscape:connector-curvature="0"
+     id="path846"
+     d="m 39.426993,41.26578 c -0.08308,-0.002 -0.162537,0.01476 -0.244177,0.01847 -0.195406,-0.01104 -0.394663,-0.0078 -0.595581,0.02219 -0.671494,0.09826 -1.359798,0.439289 -1.985268,1.097637 L 36.166705,42.984362 3.911539,86.00785 c -1.4521873,1.95837 -0.089029,5.089411 2.840468,4.758942 l 35.051779,-4.999463 7.486826,52.499391 c 0.143332,1.06941 0.708175,1.87792 1.45651,2.37853 0.06099,0.57446 0.300326,1.15825 0.786491,1.67605 l 54.221237,55.16042 c 0.35241,0.34946 0.76163,0.57974 1.18925,0.71967 l 43.2449,43.9932 c 2.19797,2.06517 5.73881,0.59111 5.73827,-2.44537 l 0.72154,-88.30898 100.76861,-99.226182 c 2.03273,-1.933848 0.52846,-5.096585 -1.98911,-5.01476 L 146.21842,46.315471 c -1.15721,-0.0078 -1.82288,0.589677 -2.08644,0.84183 L 70.489255,119.67376 95.234723,86.666413 c 1.320352,-1.808803 0.561745,-3.846193 -0.6872,-4.787579 L 41.349464,41.92492 C 40.706305,41.485816 40.049657,41.2839 39.427179,41.266357 Z"
+     style="fill:#29344a;fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" /></svg>

--- a/frappe_theme/public/less/frappe_theme.less
+++ b/frappe_theme/public/less/frappe_theme.less
@@ -306,7 +306,6 @@ display:inline-block;
 footer li a {
     text-decoration: none;
     color: #36414c;
-    font-size: 16px;
 }
 
 .social {


### PR DESCRIPTION
Added new frappe logo to website
![screenshot_20180216_005028](https://user-images.githubusercontent.com/9101092/36276279-6332be6a-12b3-11e8-82d4-0ef951fc1a6b.png)
