### PR TITLE
[fix] check if repo exists

### DIFF
--- a/frappe_theme/templates/web.html
+++ b/frappe_theme/templates/web.html
@@ -44,7 +44,7 @@
 				{% if add_next_prev_links %}
 				{% include 'templates/includes/next-prev-links.html' %}
 				{% endif %}
-				{% if show_sidebar and template.endswith('.md') %}
+				{% if show_sidebar and template.endswith('.md') and repo %}
 					<a class='text-muted improve-link' target='_blank'
 						href="https://github.com/{{ repo }}/blob/master/{{ repo.split('/')[1] }}/{{ template }}">
 						Improve this page</a>


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/website/render.py", line 45, in render
    data = render_page_by_language(path)
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/website/render.py", line 139, in render_page_by_language
    return render_page(path)
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/website/render.py", line 155, in render_page
    return build(path)
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/website/render.py", line 162, in build
    return build_page(path)
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/website/render.py", line 181, in build_page
    html = frappe.render_template(context.source, context)
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/utils/jinja.py", line 69, in render_template
    return get_jenv().from_string(template).render(context)
  File "/home/frappe/benches/bench-2016-07-23/env/lib/python2.7/site-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/frappe/benches/bench-2016-07-23/env/lib/python2.7/site-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 1, in top-level template code
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe_theme/frappe_theme/./templates/web.html", line 1, in top-level template code
    {% extends base_template_path %}
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe_theme/frappe_theme/./templates/base.html", line 43, in top-level template code
    {% block content %}
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe_theme/frappe_theme/./templates/web.html", line 69, in block "content"
    {{ main_content() }}
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe_theme/frappe_theme/./templates/web.html", line 49, in template
    href="https://github.com/{{ repo }}/blob/master/{{ repo.split('/')[1] }}/{{ template }}">
  File "/home/frappe/benches/bench-2016-07-23/env/lib/python2.7/site-packages/jinja2/environment.py", line 408, in getattr
    return getattr(obj, attribute)
UndefinedError: 'repo' is undefined
```