### PR TITLE
fix: apply style rules to page-search

### DIFF
--- a/frappe_theme/public/scss/style.scss
+++ b/frappe_theme/public/scss/style.scss
@@ -932,6 +932,7 @@ body[frappe-content-type="markdown"] {
 }
 
 #page-search_docs,
+#page-search,
 #page-list,
 .from-markdown,
 div[source-type="Generator"][data-doctype="Blog Post"],


### PR DESCRIPTION
Fix container rules for search in docs.erpnext.com

<img width="1920" alt="Screenshot 2020-03-29 at 11 07 25 AM" src="https://user-images.githubusercontent.com/18097732/77842230-7a199800-71ad-11ea-9d15-7e754c14f50e.png">
