### PR TITLE
fix: spacing added between breadcrumbs and title

### DIFF
--- a/frappe_theme/public/scss/style.scss
+++ b/frappe_theme/public/scss/style.scss
@@ -815,6 +815,10 @@ body[frappe-content-type="markdown"] {
 		padding-right: 0;
 	}
 
+	.page-breadcrumbs {
+		margin-bottom: 2.5rem;
+	}
+
 	.navbar {
 		border-bottom: 1px solid $border-color;
 	}
@@ -828,7 +832,7 @@ body[frappe-content-type="markdown"] {
 	p.lead {
 		font-size: 1.1rem;
 		margin-top: -1.5rem !important;
-		padding-bottom: 3rem;
+		padding-bottom: 1.5rem;
 	}
 
 	h2 {


### PR DESCRIPTION
Before:
![tt](https://user-images.githubusercontent.com/15175501/82156821-397bf800-989b-11ea-944a-707e6837c0f7.png)

After:
![tt1](https://user-images.githubusercontent.com/15175501/82156839-5ca6a780-989b-11ea-9e68-fd914c26a091.png)