### PR TITLE
fix: erpnext-jobs page render

### DIFF
--- a/frappe_theme/templates/web.html
+++ b/frappe_theme/templates/web.html
@@ -24,7 +24,7 @@
 			{% if add_next_prev_links %}
 			{% include 'templates/includes/next-prev-links.html' %}
 			{% endif %}
-			{% if template.endswith('.md') and repo %}
+			{% if template and template.endswith('.md') and repo %}
 				<a class='text-muted improve-link' target='_blank'
 					href="https://github.com/{{ repo }}/blob/master/{{ repo.split('/')[1] }}/{{ template }}">
 					Improve this page</a>


### PR DESCRIPTION
The erpnext-jobs page is failing to build because `template` is accessed without checking for null. This patch fixes that.

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/serve.py", line 17, in get_response
    response = renderer_instance.render()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/page_renderers/document_page.py", line 50, in render
    html = self.get_html()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/utils.py", line 443, in cache_html_decorator
    html = func(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/page_renderers/document_page.py", line 61, in get_html
    html = frappe.get_template(self.template_path).render(self.context)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/jinja2/environment.py", line 1304, in render
    self.environment.handle_exception()
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/jinja2/environment.py", line 925, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/home/frappe/frappe-bench/apps/foundation/foundation/./erpnext_foundation/doctype/portal_job/templates/portal_job.html", line 1, in top-level template code
    {% extends "templates/web.html" %}
  File "/home/frappe/frappe-bench/apps/frappe_theme/frappe_theme/./templates/web.html", line 1, in top-level template code
    {% extends "frappe/templates/web.html" %}
  File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/web.html", line 1, in top-level template code
    {% extends base_template_path %}
  File "/home/frappe/frappe-bench/apps/frappe_theme/frappe_theme/./templates/base.html", line 1, in top-level template code
    {% extends "frappe/templates/base.html" %}
  File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/base.html", line 83, in top-level template code
    {% block content %}
  File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/web.html", line 72, in block 'content'
    {{ main_content() }}
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/jinja2/sandbox.py", line 393, in call
    return __context.call(__obj, *args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/jinja2/runtime.py", line 828, in _invoke
    rv = self._func(*arguments)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/web.html", line 15, in template
    {% block page_container %}
  File "/home/frappe/frappe-bench/apps/frappe_theme/frappe_theme/./templates/web.html", line 22, in block 'page_container'
    {%- block page_footer -%}
  File "/home/frappe/frappe-bench/apps/frappe_theme/frappe_theme/./templates/web.html", line 27, in block 'page_footer'
    {% if template.endswith('.md') and repo %}
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/jinja2/sandbox.py", line 326, in getattr
    value = getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'template' is undefined
```

Signed-off-by: Syed Mujeer Hashmi <mujeerhashmi@4csolutions.in>